### PR TITLE
Self-Fulfilling feature request: add update dates to the Subscriptions pages

### DIFF
--- a/app/views/subscriptions/index.html.erb
+++ b/app/views/subscriptions/index.html.erb
@@ -52,7 +52,7 @@
         <%= ts("Updated:") %> <%= subscription.subscribable.revised_at ? subscription.subscribable.revised_at.to_date : subscription.subscribable.published_at %>
       <% end %>
       <% if subscription.subscribable_type == "User" and subscription.subscribable.works.size > 0 %>
-        <%= ts("Updated:") %> <%= subscription.subscribable.works.map { |w| w.revised_at }.sort.last.to_date %>
+        <%= ts("Updated:") %> <%= subscription.subscribable.works.map(&:revised_at).max.to_date %>
       <% end %>
     </dt>
     <dd>

--- a/app/views/subscriptions/index.html.erb
+++ b/app/views/subscriptions/index.html.erb
@@ -51,7 +51,7 @@
       <% if ["Series", "Work"].include?(subscription.subscribable_type) %>
         <%= ts("Updated:") %> <%= subscription.subscribable.revised_at ? subscription.subscribable.revised_at.to_date : subscription.subscribable.published_at %>
       <% end %>
-      <% if subscription.subscribable_type == "User" and if subscription.subscribable.works.size > 0 %>
+      <% if subscription.subscribable_type == "User" and subscription.subscribable.works.size > 0 %>
         <%= ts("Updated:") %> <%= subscription.subscribable.works.map { |w| w.revised_at }.sort.last.to_date %>
       <% end %>
     </dt>

--- a/app/views/subscriptions/index.html.erb
+++ b/app/views/subscriptions/index.html.erb
@@ -51,6 +51,9 @@
       <% if ["Series", "Work"].include?(subscription.subscribable_type) %>
         <%= ts("Updated:") %> <%= subscription.subscribable.revised_at ? subscription.subscribable.revised_at.to_date : subscription.subscribable.published_at %>
       <% end %>
+      <% if subscription.subscribable_type == "User" and if subscription.subscribable.works.size > 0 %>
+        <%= ts("Updated:") %> <%= subscription.subscribable.works.map { |w| w.revised_at }.sort.last.to_date %>
+      <% end %>
     </dt>
     <dd>
       <%= form_for [current_user, subscription], :html => {:method => :delete} do |f| %>

--- a/app/views/subscriptions/index.html.erb
+++ b/app/views/subscriptions/index.html.erb
@@ -48,6 +48,9 @@
       <% unless subscription.subscribable_type == "User" %>
         <%= ts('by %{creators}', :creators => byline(subscription.subscribable)).html_safe %>
       <% end %>
+      <% if ["Series", "Work"].include?(subscription.subscribable_type) %>
+        <%= ts("Updated:") %> <%= subscription.subscribable.revised_at ? subscription.subscribable.revised_at.to_date : subscription.subscribable.published_at %>
+      <% end %>
     </dt>
     <dd>
       <%= form_for [current_user, subscription], :html => {:method => :delete} do |f| %>

--- a/features/other_b/subscriptions.feature
+++ b/features/other_b/subscriptions.feature
@@ -175,20 +175,20 @@
     And the subscription should show an update date
     And I should see "Awesome Story (Work)"
     And the subscription should show an update date
-  When I follow "Series Subscriptions"
-  Then I should see "My Series Subscriptions"
-    And I should see "Awesome Series"
-    And I should not see "(Series)"
-    And the subscription should show an update date
-  When I follow "User Subscriptions"
-  Then I should see "My User Subscriptions"
-    And I should see "third_user"
-    And the subscription should show an update date
-  When I follow "Work Subscriptions"
-  Then I should see "My Work Subscriptions"
-    And I should see "Awesome Story"
-    And I should not see "(Work)"
-    And the subscription should show an update date
+  # When I follow "Series Subscriptions"
+  # Then I should see "My Series Subscriptions"
+  #   And I should see "Awesome Series"
+  #   And I should not see "(Series)"
+  #   And the subscription should show an update date
+  # When I follow "User Subscriptions"
+  # Then I should see "My User Subscriptions"
+  #   And I should see "third_user"
+  #   And the subscription should show an update date
+  # When I follow "Work Subscriptions"
+  # Then I should see "My Work Subscriptions"
+  #   And I should see "Awesome Story"
+  #   And I should not see "(Work)"
+  #   And the subscription should show an update date
 
   Scenario: Subscribe to a multi-chapter work should redirect you back to the chapter you were viewing
 

--- a/features/other_b/subscriptions.feature
+++ b/features/other_b/subscriptions.feature
@@ -170,25 +170,25 @@
   When I am on my subscriptions page
   Then I should see "My Subscriptions"
     And I should see "Awesome Series (Series)"
+    And the subscription should show an update date
     And I should see "third_user"
+    And the subscription should show an update date
     And I should see "Awesome Story (Work)"
+    And the subscription should show an update date
   When I follow "Series Subscriptions"
   Then I should see "My Series Subscriptions"
     And I should see "Awesome Series"
     And I should not see "(Series)"
-    And I should not see "third_user"
-    And I should not see "Awesome Story"
+    And the subscription should show an update date
   When I follow "User Subscriptions"
   Then I should see "My User Subscriptions"
     And I should see "third_user"
-    And I should not see "Awesome Series"
-    And I should not see "Awesome Story"
+    And the subscription should show an update date
   When I follow "Work Subscriptions"
   Then I should see "My Work Subscriptions"
     And I should see "Awesome Story"
     And I should not see "(Work)"
-    And I should not see "Awesome Series"
-    And I should not see "third_user"
+    And the subscription should show an update date
 
   Scenario: Subscribe to a multi-chapter work should redirect you back to the chapter you were viewing
 

--- a/features/other_b/subscriptions.feature
+++ b/features/other_b/subscriptions.feature
@@ -171,22 +171,26 @@
     And "second_user" subscribes to work "Awesome Story"
     And "second_user" subscribes to series "Awesome Series"
   When I am on my subscriptions page
-  Then I should see "Awesome Series (Series)"
+  Then I should see "My Subscriptions"
+    And I should see "Awesome Series (Series)"
     And the subscription should show an update date
     And I should see "third_user"
     And the subscription should show an update date
     And I should see "Awesome Story (Work)"
     And the subscription should show an update date
   When I follow "Series Subscriptions"
-  Then I should see "Awesome Series"
+  Then I should see "My Series Subscriptions"
+    And I should see "Awesome Series"
     And I should not see "(Series)"
     And the subscription should show an update date
   When I follow "User Subscriptions"
-  Then I should see "third_user"
-    Then I should see "first_user"
+  Then I should see "My User Subscriptions"
+    And I should see "third_user"
+    And I should see "first_user"
     And the subscription should show an update date
   When I follow "Work Subscriptions"
-  Then I should see "Awesome Story"
+  Then I should see "My Work Subscriptions"
+    And I should see "Awesome Story"
     And I should not see "(Work)"
     And the subscription should show an update date
 

--- a/features/other_b/subscriptions.feature
+++ b/features/other_b/subscriptions.feature
@@ -168,27 +168,27 @@
     And "second_user" subscribes to work "Awesome Story"
     And "second_user" subscribes to series "Awesome Series"
   When I am on my subscriptions page
-  Then I should see "My Subscriptions"
-    And I should see "Awesome Series (Series)"
+  # Then I should see "My Subscriptions"
+    Then I should see "Awesome Series (Series)"
     And the subscription should show an update date
     And I should see "third_user"
     And the subscription should show an update date
     And I should see "Awesome Story (Work)"
     And the subscription should show an update date
-  # When I follow "Series Subscriptions"
+  When I follow "Series Subscriptions"
   # Then I should see "My Series Subscriptions"
-  #   And I should see "Awesome Series"
-  #   And I should not see "(Series)"
-  #   And the subscription should show an update date
-  # When I follow "User Subscriptions"
+    Then I should see "Awesome Series"
+    And I should not see "(Series)"
+    And the subscription should show an update date
+  When I follow "User Subscriptions"
   # Then I should see "My User Subscriptions"
-  #   And I should see "third_user"
-  #   And the subscription should show an update date
-  # When I follow "Work Subscriptions"
+    Then I should see "third_user"
+    And the subscription should show an update date
+  When I follow "Work Subscriptions"
   # Then I should see "My Work Subscriptions"
-  #   And I should see "Awesome Story"
-  #   And I should not see "(Work)"
-  #   And the subscription should show an update date
+    Then I should see "Awesome Story"
+    And I should not see "(Work)"
+    And the subscription should show an update date
 
   Scenario: Subscribe to a multi-chapter work should redirect you back to the chapter you were viewing
 

--- a/features/other_b/subscriptions.feature
+++ b/features/other_b/subscriptions.feature
@@ -163,30 +163,30 @@
 
   Scenario: subscriptions on a user's subscription page show date of last update
 
+  When I am logged in as "first_user"
+    And I post the work "The First Awesome Story"
   When I am logged in as "second_user"
     And "second_user" subscribes to author "third_user"
+    And "second_user" subscribes to author "first_user"
     And "second_user" subscribes to work "Awesome Story"
     And "second_user" subscribes to series "Awesome Series"
   When I am on my subscriptions page
-  # Then I should see "My Subscriptions"
-    Then I should see "Awesome Series (Series)"
+  Then I should see "Awesome Series (Series)"
     And the subscription should show an update date
     And I should see "third_user"
     And the subscription should show an update date
     And I should see "Awesome Story (Work)"
     And the subscription should show an update date
   When I follow "Series Subscriptions"
-  # Then I should see "My Series Subscriptions"
-    Then I should see "Awesome Series"
+  Then I should see "Awesome Series"
     And I should not see "(Series)"
     And the subscription should show an update date
   When I follow "User Subscriptions"
-  # Then I should see "My User Subscriptions"
-    Then I should see "third_user"
+  Then I should see "third_user"
+    Then I should see "first_user"
     And the subscription should show an update date
   When I follow "Work Subscriptions"
-  # Then I should see "My Work Subscriptions"
-    Then I should see "Awesome Story"
+  Then I should see "Awesome Story"
     And I should not see "(Work)"
     And the subscription should show an update date
 

--- a/features/other_b/subscriptions.feature
+++ b/features/other_b/subscriptions.feature
@@ -172,26 +172,21 @@
     And "second_user" subscribes to series "Awesome Series"
   When I am on my subscriptions page
   Then I should see "My Subscriptions"
-    And I should see "Awesome Series (Series)"
-    And the subscription should show an update date
+    And I should see "Awesome Series (Series)" with author and update date
     And I should see "third_user"
-    And the subscription should show an update date
-    And I should see "Awesome Story (Work)"
-    And the subscription should show an update date
+    And I should not see "third_user" with an update date
+    And I should see "first_user" with an update date
+    And I should see "Awesome Story (Work)" with author and update date
   When I follow "Series Subscriptions"
   Then I should see "My Series Subscriptions"
-    And I should see "Awesome Series"
-    And I should not see "(Series)"
-    And the subscription should show an update date
+    And I should see "Awesome Series" with author and update date
   When I follow "User Subscriptions"
   Then I should see "My User Subscriptions"
     And I should see "third_user"
-    And I should see "first_user" with an update date
+    And I should not see "third_user" with an update date
   When I follow "Work Subscriptions"
   Then I should see "My Work Subscriptions"
-    And I should see "Awesome Story"
-    And I should not see "(Work)"
-    And the subscription should show an update date
+    And I should see "Awesome Story" with author and update date
 
   Scenario: Subscribe to a multi-chapter work should redirect you back to the chapter you were viewing
 

--- a/features/other_b/subscriptions.feature
+++ b/features/other_b/subscriptions.feature
@@ -186,8 +186,7 @@
   When I follow "User Subscriptions"
   Then I should see "My User Subscriptions"
     And I should see "third_user"
-    And I should see "first_user"
-    And the subscription should show an update date
+    And I should see "first_user" with an update date
   When I follow "Work Subscriptions"
   Then I should see "My Work Subscriptions"
     And I should see "Awesome Story"

--- a/features/other_b/subscriptions.feature
+++ b/features/other_b/subscriptions.feature
@@ -161,6 +161,35 @@
     And I should not see "Awesome Series"
     And I should not see "third_user"
 
+  Scenario: subscriptions on a user's subscription page show date of last update
+
+  When I am logged in as "second_user"
+    And "second_user" subscribes to author "third_user"
+    And "second_user" subscribes to work "Awesome Story"
+    And "second_user" subscribes to series "Awesome Series"
+  When I am on my subscriptions page
+  Then I should see "My Subscriptions"
+    And I should see "Awesome Series (Series)"
+    And I should see "third_user"
+    And I should see "Awesome Story (Work)"
+  When I follow "Series Subscriptions"
+  Then I should see "My Series Subscriptions"
+    And I should see "Awesome Series"
+    And I should not see "(Series)"
+    And I should not see "third_user"
+    And I should not see "Awesome Story"
+  When I follow "User Subscriptions"
+  Then I should see "My User Subscriptions"
+    And I should see "third_user"
+    And I should not see "Awesome Series"
+    And I should not see "Awesome Story"
+  When I follow "Work Subscriptions"
+  Then I should see "My Work Subscriptions"
+    And I should see "Awesome Story"
+    And I should not see "(Work)"
+    And I should not see "Awesome Series"
+    And I should not see "third_user"
+
   Scenario: Subscribe to a multi-chapter work should redirect you back to the chapter you were viewing
 
   When I am logged in as "first_user"

--- a/features/step_definitions/subscription_steps.rb
+++ b/features/step_definitions/subscription_steps.rb
@@ -42,3 +42,14 @@ Then /^I should see "([^\"]*)" with an update date$/ do |text|
   today = DateTime.now().strftime('%F')
   step %{I should see "#{text} Updated: #{today}"}
 end
+
+Then /^I should see "([^\"]*)" with author and update date$/ do |text|
+  today = DateTime.now().strftime('%F')
+  target_regex = /#{Regexp.escape(text)} by \w+ Updated: #{Regexp.escape(today)}/
+  page.should have_content(target_regex)
+end
+
+Then /^I should not see "([^\"]*)" with an update date$/ do |text|
+  today = DateTime.now().strftime('%F')
+  step %{I should not see "#{text} Updated: #{today}"}
+end

--- a/features/step_definitions/subscription_steps.rb
+++ b/features/step_definitions/subscription_steps.rb
@@ -37,3 +37,8 @@ Then /^the subscription should show an update date$/ do
   today = DateTime.now().strftime('%F')
   step %{I should see "Updated: #{today}"}
 end
+
+Then /^I should see "([^\"]*)" with an update date$/ do |text|
+  today = DateTime.now().strftime('%F')
+  step %{I should see "#{text} Updated: #{today}"}
+end

--- a/features/step_definitions/subscription_steps.rb
+++ b/features/step_definitions/subscription_steps.rb
@@ -32,3 +32,8 @@ When /^"([^\"]*)" subscribes to (author|work|series) "([^\"]*)"$/ do |user, type
   step %{I go to my subscriptions page}
   step %{I should see an "Unsubscribe from #{name}" button}
 end
+
+When /^the subscription should show an update date$/ do
+  today = DateTime.now().strftime('2001-02-03')
+  step %{I should see "Updated: #{today}"}
+end

--- a/features/step_definitions/subscription_steps.rb
+++ b/features/step_definitions/subscription_steps.rb
@@ -34,17 +34,17 @@ When /^"([^\"]*)" subscribes to (author|work|series) "([^\"]*)"$/ do |user, type
 end
 
 Then /^I should see "([^\"]*)" with an update date$/ do |text|
-  today = DateTime.now().strftime('%F')
+  today = DateTime.now.strftime("%F")
   step %{I should see "#{text} Updated: #{today}"}
 end
 
 Then /^I should see "([^\"]*)" with author and update date$/ do |text|
-  today = DateTime.now().strftime('%F')
+  today = DateTime.now.strftime("%F")
   target_regex = /#{Regexp.escape(text)} by \w+ Updated: #{Regexp.escape(today)}/
   page.should have_content(target_regex)
 end
 
 Then /^I should not see "([^\"]*)" with an update date$/ do |text|
-  today = DateTime.now().strftime('%F')
+  today = DateTime.now.strftime("%F")
   step %{I should not see "#{text} Updated: #{today}"}
 end

--- a/features/step_definitions/subscription_steps.rb
+++ b/features/step_definitions/subscription_steps.rb
@@ -33,7 +33,7 @@ When /^"([^\"]*)" subscribes to (author|work|series) "([^\"]*)"$/ do |user, type
   step %{I should see an "Unsubscribe from #{name}" button}
 end
 
-When /^the subscription should show an update date$/ do
+Then /^the subscription should show an update date$/ do
   today = DateTime.now().strftime('%F')
   step %{I should see "Updated: #{today}"}
 end

--- a/features/step_definitions/subscription_steps.rb
+++ b/features/step_definitions/subscription_steps.rb
@@ -33,11 +33,6 @@ When /^"([^\"]*)" subscribes to (author|work|series) "([^\"]*)"$/ do |user, type
   step %{I should see an "Unsubscribe from #{name}" button}
 end
 
-Then /^the subscription should show an update date$/ do
-  today = DateTime.now().strftime('%F')
-  step %{I should see "Updated: #{today}"}
-end
-
 Then /^I should see "([^\"]*)" with an update date$/ do |text|
   today = DateTime.now().strftime('%F')
   step %{I should see "#{text} Updated: #{today}"}

--- a/features/step_definitions/subscription_steps.rb
+++ b/features/step_definitions/subscription_steps.rb
@@ -34,6 +34,6 @@ When /^"([^\"]*)" subscribes to (author|work|series) "([^\"]*)"$/ do |user, type
 end
 
 When /^the subscription should show an update date$/ do
-  today = DateTime.now().strftime('2001-02-03')
+  today = DateTime.now().strftime('%F')
   step %{I should see "Updated: #{today}"}
 end


### PR DESCRIPTION
This PR both proposes a feature request and fulfills that feature request: displaying date of update on Subscription pages.

# Pull Request Checklist

* [ ] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)

## Issue

No existing issue. 

https://otwarchive.atlassian.net/browse/AO3-XXXX (Please fill in issue number and remove this comment.)

## Purpose

On the subscriptions page(s), add "Updated: YYYY-MM-DD" to each subscription, after the author name.

## Testing Instructions

Automated cucumber tests are sufficient.

## Credit

Jacob Kopczynski, prefer not to have pronouns specified